### PR TITLE
surveyed package versioning and bumped to recent stable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ First public release of the Books of Life Toolkit (BOLT).
   issue/PR templates.
 
 ### Fixed
+- Bumped vulnerable dependencies: duckdb (≥1.1), aiohttp, urllib3, pyarrow in
+  `requirements.txt` and `requirements-lock.txt`.
 - Person attributes were shifted by one column, mislabeling every demographic
   field in every book.
 - Synthetic household data used descriptive strings where the instantiator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "duckdb>=1.0",
+    "duckdb>=1.1",
     "pandas>=2.2",
     "numpy>=2.0",
     "PyYAML>=6.0",

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -3,14 +3,14 @@
 # For normal use, prefer `pip install -r requirements.txt` (core) or the
 # pyproject extras (`pip install -e .[stats,dev]`).
 aiohappyeyeballs==2.3.4
-aiohttp==3.10.0
+aiohttp==3.13.4
 aiosignal==1.3.1
 attrs==23.2.0
 certifi==2024.7.4
 charset-normalizer==3.3.2
 datasets==2.20.0
 dill==0.3.8
-duckdb==1.0.0
+duckdb==1.2.2
 filelock==3.15.4
 frozenlist==1.4.1
 fsspec==2024.5.0
@@ -21,7 +21,7 @@ multiprocess==0.70.16
 numpy==2.0.1
 packaging==24.1
 pandas==2.2.2
-pyarrow==17.0.0
+pyarrow==18.1.0
 pyarrow-hotfix==0.6
 python-dateutil==2.9.0.post0
 pytz==2024.1
@@ -34,6 +34,6 @@ tqdm==4.66.4
 transformers==4.53.2
 typing_extensions==4.12.2
 tzdata==2024.1
-urllib3==2.2.2
+urllib3==2.2.3
 xxhash==3.4.1
 yarl==1.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #   - requirements-stats.txt : token-length statistics / fine-tuning helpers
 #   - requirements-lock.txt  : fully pinned environment for exact reproduction
 # Or install via pyproject extras: `pip install -e .[stats,dev]`
-duckdb==1.0.0
+duckdb==1.2.2
 pandas==2.2.2
 numpy==2.0.1
 PyYAML==6.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,11 +55,15 @@ def conn(tmp_path):
     """A DuckDB connection to a freshly built, fully-known toy database."""
     db_path = str(tmp_path / "test.duckdb")
     connection = duckdb.connect(db_path)
-    connection.register("persoon_df", PERSOON_TAB)
-    connection.register("household_df", HOUSEHOLD_BUS)
-    connection.execute("CREATE TABLE persoon_tab AS SELECT * FROM persoon_df")
-    connection.execute("CREATE TABLE household_bus AS SELECT * FROM household_df")
-    connection.unregister("persoon_df")
-    connection.unregister("household_df")
+    persoon_csv = tmp_path / "persoon_tab.csv"
+    household_csv = tmp_path / "household_bus.csv"
+    PERSOON_TAB.to_csv(persoon_csv, index=False)
+    HOUSEHOLD_BUS.to_csv(household_csv, index=False)
+    connection.execute(
+        f"CREATE TABLE persoon_tab AS SELECT * FROM read_csv_auto('{persoon_csv}', all_varchar=true)"
+    )
+    connection.execute(
+        f"CREATE TABLE household_bus AS SELECT * FROM read_csv_auto('{household_csv}', all_varchar=true)"
+    )
     yield connection
     connection.close()


### PR DESCRIPTION
## Summary
Addresses Dependabot high-severity alerts on pinned dependencies in requirements-lock.txt. Bumps duckdb in the core install path (fixes CVE-2024-41672) and updates stats-only transitive deps (aiohttp, urllib3, pyarrow) in the lock file. Includes a small test fixture fix required for DuckDB ≥1.1.

## Changes
Bump duckdb 1.0.0 → 1.2.2 in requirements.txt; set duckdb>=1.1 in pyproject.toml
Bump pinned stats/transitive deps in requirements-lock.txt: aiohttp 3.13.4, urllib3 2.2.3, pyarrow 18.1.0
Update test fixture in tests/conftest.py to load toy data via CSV (all_varchar=true) instead of connection.register(), matching make_db.py and fixing DuckDB ≥1.1 + pandas string dtype incompatibility
Note dependency bumps in CHANGELOG.md

## Testing

- [x] pytest -q passes
- [x] Ran the synthetic quickstart (synth/main.py → make_db.py → main.py)

## Notes

duckdb is a core dependency (every install); the other three are only pulled in via the optional [stats] / requirements-lock.txt path.